### PR TITLE
ci: use PAT token in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by configuring the checkout step to use a custom token for authentication. This allows the workflow to perform actions that require higher permissions, such as pushing changes to protected branches.

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R30): Added the `token` field to the `actions/checkout` step, using the `RELEASE_TOKEN` secret.